### PR TITLE
Improved shiftleft scan config

### DIFF
--- a/.github/workflows/shiftleft-analysis.yml
+++ b/.github/workflows/shiftleft-analysis.yml
@@ -30,7 +30,7 @@ jobs:
         output: reports
         # Scan auto-detects the languages in your project. To override uncomment the below variable and set the type
         # type: credscan,java
-        # type: python
+        type: credscan,nodejs,depscan
 
     - name: Upload report
       uses: github/codeql-action/upload-sarif@v1


### PR DESCRIPTION
Hi,

Thank you for trying scan. I noticed that the default configuration from github was not useful. This PR includes the required config changes to improve scan performance.

A number of issues is being reported for this repo so requires some manual triaging. Eg run https://github.com/prabhu/flight-manual.atom.io/runs/780939948?check_suite_focus=true#step:6:29